### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Overview
+
+_Replace with a general description or bullet-points of the change._
+
+_Add a screenshot if you made significant changes to any views._
+
+## Feedback Requested
+
+_Tell your fellow devs what type of feedback you would like._
+
+## QA & Rollout Plan
+
+_Replace with your plan to validate this PR: manual testing on QA server, integration test, unit tests, or a combination._
+
+## Final checklist:
+Before release:
+- [ ] Completed **self-code review**
+- [ ] **Unit tests** cover full change


### PR DESCRIPTION
## Overview

This PR adds one file, pull_request_template.md. If it is present, Github will use it when you create a
new pull request. This is useful to suggest what should be in the pull request summary (this blob).

Here are some links, but I had my own that I used more than these:
* https://blog.echobind.com/imagine-youve-recently-hired-a-new-engineer-to-join-your-team-224df7e5b967 / https://github.com/echobind/pr-templates

## Feedback Requested

If you think it should have other stuff, please add a comment. 

## QA & Rollout Plan

Tara merges it into her repo.

## Final checklist:
Before release:
- [x] Completed **self-code review**
